### PR TITLE
feat:  Add ASSERT_NEAR GTest adapter

### DIFF
--- a/src/aunit/contrib/gtest.h
+++ b/src/aunit/contrib/gtest.h
@@ -70,4 +70,6 @@ SOFTWARE.
 #define ASSERT_TRUE(x) assertTrue(x)
 #define ASSERT_FALSE(x) assertFalse(x)
 
+#define ASSERT_NEAR(e, a, error) assertNear(static_cast<decltype(a)>(e), a, static_cast<decltype(a)>(error))
+
 #endif


### PR DESCRIPTION
I saw that you added assertNear in a previous release.  I figured I would add the GTest macro.