### PR TITLE
TimeoutType uint8_t to uint16_t. (fixes #57)

### DIFF
--- a/src/aunit/TestRunner.h
+++ b/src/aunit/TestRunner.h
@@ -40,8 +40,8 @@ namespace aunit {
  */
 class TestRunner {
   public:
-    /** Integer type of the timeout parameter. Seconds. */
-    typedef uint8_t TimeoutType;
+    /** Integer type of the timeout parameter. Seconds. Default is kTimeoutDefault = 10 */
+    typedef unsigned int TimeoutType;
 
     /** Run all tests using the current runner. */
     static void run() { getRunner()->runTest(); }

--- a/src/aunit/TestRunner.h
+++ b/src/aunit/TestRunner.h
@@ -41,7 +41,7 @@ namespace aunit {
 class TestRunner {
   public:
     /** Integer type of the timeout parameter. Seconds. Default is kTimeoutDefault = 10 */
-    typedef uint16_t int TimeoutType;
+    typedef uint16_t TimeoutType;
 
     /** Run all tests using the current runner. */
     static void run() { getRunner()->runTest(); }

--- a/src/aunit/TestRunner.h
+++ b/src/aunit/TestRunner.h
@@ -41,7 +41,7 @@ namespace aunit {
 class TestRunner {
   public:
     /** Integer type of the timeout parameter. Seconds. Default is kTimeoutDefault = 10 */
-    typedef unsigned int TimeoutType;
+    typedef uint16_t int TimeoutType;
 
     /** Run all tests using the current runner. */
     static void run() { getRunner()->runTest(); }
@@ -105,7 +105,7 @@ class TestRunner {
      * Set test runner timeout across all tests, in seconds. Set to 0 for
      * infinite timeout. Useful for preventing testing() test cases that never
      * end. This is a timeout for the TestRunner itself, not for individual
-     * tests.
+     * tests. Upper limit is 65535 seconds (just over 18 hours).
      */
     static void setTimeout(TimeoutType seconds) {
       getRunner()->setRunnerTimeout(seconds);


### PR DESCRIPTION
Change `TimeoutType` from `uint8_t` to `unsigned int`. 
Add comment about where to find default value. 
Did not check in `doxygen` output, as A) paths different and might confuse B) version mismatch, orig 1.8.13 != mine 1.8.17. 
All unit tests seems to work 'as expected':
- Specifically, `test timeout_after_10_seconds timed out` did so after 10 seconds
- Others with `fail` seem to fail
- Others with `expire` seem to timeout
