### PR TITLE
Readd arduino samd (see #66)

### DIFF
--- a/src/AUnit.h
+++ b/src/AUnit.h
@@ -46,12 +46,15 @@ SOFTWARE.
 #define AUNIT_AUNIT_H
 
 // Blacklist boards using new Arduino API due to incompatibilities. This
-// currently includes all megaAVR boards and SAMD21 boards using arduino::samd
-// >= 1.8.10. Boards using arduino:samd <= 1.8.9 or SparkFun:samd are fine.
+// currently includes all megaAVR boards, and SAMD21 boards using arduino:samd
+// versions in [1.8.10, 1.8.11]. Boards using arduino:samd <= 1.8.9, >= 1.8.12,
+// or SparkFun:samd are fine.
 #if defined(ARDUINO_ARCH_MEGAAVR)
 #error MegaAVR not supported, https://github.com/bxparks/AUnit/issues/56
-#elif defined(ARDUINO_ARCH_SAMD) && defined(ARDUINO_API_VERSION)
-#error SAMD21 with arduino:samd >= 1.8.10 not supported, https://github.com/bxparks/AUnit/issues/66
+#elif defined(ARDUINO_ARCH_SAMD) \
+  && defined(ARDUINO_API_VERSION) \
+  && ARDUINO_API_VERSION <= 10200
+#error SAMD21 with arduino:samd versions [1.8.10, 1.8.11] not supported, https://github.com/bxparks/AUnit/issues/66
 #endif
 
 #include "aunit/print64.h"

--- a/src/AUnitVerbose.h
+++ b/src/AUnitVerbose.h
@@ -36,12 +36,15 @@ SOFTWARE.
 #define AUNIT_AUNIT_VERBOSE_H
 
 // Blacklist boards using new Arduino API due to incompatibilities. This
-// currently includes all megaAVR boards and SAMD21 boards using arduino::samd
-// >= 1.8.10. Boards using arduino:samd <= 1.8.9 or SparkFun:samd are fine.
+// currently includes all megaAVR boards, and SAMD21 boards using arduino:samd
+// versions in [1.8.10, 1.8.11]. Boards using arduino:samd <= 1.8.9, >= 1.8.12,
+// or SparkFun:samd are fine.
 #if defined(ARDUINO_ARCH_MEGAAVR)
-#error MegaAVR not supported https://github.com/bxparks/AUnit/issues/56
-#elif defined(ARDUINO_ARCH_SAMD) && defined(ARDUINO_API_VERSION)
-#error SAMD21 with arduino:samd >= 1.8.10 not supported, see https://github.com/bxparks/AUnit/issues/66
+#error MegaAVR not supported, https://github.com/bxparks/AUnit/issues/56
+#elif defined(ARDUINO_ARCH_SAMD) \
+  && defined(ARDUINO_API_VERSION) \
+  && ARDUINO_API_VERSION <= 10200
+#error SAMD21 with arduino:samd versions [1.8.10, 1.8.11] not supported, https://github.com/bxparks/AUnit/issues/66
 #endif
 
 #include "aunit/print64.h"


### PR DESCRIPTION
Reenable arduino:samd once a new version 1.8.12 is released.

This depends on:
* https://github.com/arduino/ArduinoCore-API/pull/144
* https://github.com/arduino/ArduinoCore-samd/pull/6