### PR TITLE
merge v1.6.1 into master

### DIFF
--- a/.github/workflows/aunit_tests.yml
+++ b/.github/workflows/aunit_tests.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Unreleased
 * 1.6.1 (2022-02-02)
-    * Upgrade tool chain and regenerate `MemoryBenchmark` and `AutoBenchmark`.
+    * Upgrade tool chain.
         * Arduino IDE from 1.8.13 to 1.8.19
         * Arduino CLI from 0.14.0 to 0.19.2
         * Arduino AVR Core from 1.8.3 to 1.8.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 * Unreleased
+* 1.6.1 (2022-02-02)
+    * Upgrade tool chain and regenerate `MemoryBenchmark` and `AutoBenchmark`.
+        * Arduino IDE from 1.8.13 to 1.8.19
+        * Arduino CLI from 0.14.0 to 0.19.2
+        * Arduino AVR Core from 1.8.3 to 1.8.4
+        * STM32duino from 2.0.0 to 2.2.0
+        * ESP8266 Core from 2.7.4 to 3.0.2
+        * ESP32 Core from 1.0.6 to 2.0.2
+        * Teensyduino from 1.54 to 1.56
+    * Downgrade SAMD21 boards into new "Tier 3: May work but unsupported"
+      category.
+    * This is a maintenance release. No functional change.
 * 1.6.0 (2021-11-02)
     * Add `TestRunner::includesub(word)` and `TestRunner::excludesub(word)`
       which includes or excludes tests based on the substring match on the

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ AUnit also supports exclude and include filters:
 * `TestRunner::exclude()`
 * `TestRunner::include()`
 
+Filters can be accessed through
+[Command Line Flags](##CommandLineFlagsAndArguments) on desktop machines using
+EpoxyDuino
+
 The various assertion and test status messages can be enabled or disabled using
 the `Verbosity` flags on per test basis:
 * `enableVerbosity()`
@@ -259,17 +263,21 @@ In the `tests/` directory:
 * `SetupAndTeardownTest` - tests to verify that `setup()` and `teardown()` are
   called properly by the finite state machine
 
-Perhaps the best way to see AUnit in action through real life examples. I
-currently have 3 Arduino project using AUnit extensively
-(look under the `tests/` directory in each project).
+Perhaps the best way to see AUnit in action through real life examples. All my
+libraries use AUnit for testing and for continuous integration through
+EpoxyDuino. Here are some examples:
 
 * [AceButton](https://github.com/bxparks/AceButton)
-    * Originally created using ArduinoUnit 2.2, and I have kept those tests
-      backwards compatible. They do not use the new features of AUnit.
+    * My first Arduino library, which originally used ArduinoUnit 2.2.
+    * I kept many of the original ArduinoUnit tests for backwards compatibility
+      testing. But over time, I started to use nore AUnit features.
+* [AceCRC](https://github.com/bxparks/AceCRC)
+* [AceCommon](https://github.com/bxparks/AceCommon)
 * [AceRoutine](https://github.com/bxparks/AceRoutine)
-    * Demonstrates the full power of AUnit better.
+* [AceSegment](https://github.com/bxparks/AceSegment)
+* [AceSorting](https://github.com/bxparks/AceSorting)
+* [AceTimeClock](https://github.com/bxparks/AceTimeClock)
 * [AceTime](https://github.com/bxparks/AceTime)
-    * Demonstrates the full power of AUnit better.
 
 <a name="Usage"></a>
 ## Usage

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ instead of having to go through the Arduino IDE. Both the AUniter and
 EpoxyDuino tools can be used in a continuous integration system like Jenkins,
 or with [GitHub Actions](https://github.com/features/actions).
 
-**Version**: 1.6 (2021-11-02)
+**Version**: 1.6.1 (2022-02-02)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 
@@ -1906,6 +1906,7 @@ The library is tested on the following boards:
 
 I will occasionally test on the following hardware as a sanity check:
 
+* Arduino Pro Mini (16 MHz ATmega328P)
 * Mini Mega 2560 (Arduino Mega 2560 compatible, 16 MHz ATmega2560)
 * Teensy LC (48 MHz ARM Cortex-M0+)
 
@@ -1925,16 +1926,17 @@ The following boards are **not** supported:
 ### Tool Chain
 
 This library was validated using:
-* [Arduino IDE 1.8.13](https://www.arduino.cc/en/Main/Software)
-* [Arduino CLI 0.14.0](https://arduino.github.io/arduino-cli)
-* [Arduino AVR Boards 1.8.3](https://github.com/arduino/ArduinoCore-avr)
+
+* [Arduino IDE 1.8.19](https://www.arduino.cc/en/Main/Software)
+* [Arduino CLI 0.19.2](https://arduino.github.io/arduino-cli)
+* [Arduino AVR Boards 1.8.4](https://github.com/arduino/ArduinoCore-avr)
 * [Arduino SAMD Boards 1.8.9](https://github.com/arduino/ArduinoCore-samd)
 * [SparkFun AVR Boards 1.1.13](https://github.com/sparkfun/Arduino_Boards)
-* [SparkFun SAMD Boards 1.8.1](https://github.com/sparkfun/Arduino_Boards)
-* [STM32duino 2.0.0](https://github.com/stm32duino/Arduino_Core_STM32)
-* [ESP8266 Arduino 2.7.4](https://github.com/esp8266/Arduino)
-* [ESP32 Arduino 1.0.6](https://github.com/espressif/arduino-esp32)
-* [Teensyduino 1.54](https://www.pjrc.com/teensy/td_download.html)
+* [SparkFun SAMD Boards 1.8.6](https://github.com/sparkfun/Arduino_Boards)
+* [STM32duino 2.2.0](https://github.com/stm32duino/Arduino_Core_STM32)
+* [ESP8266 Arduino 3.0.2](https://github.com/esp8266/Arduino)
+* [ESP32 Arduino 2.0.2](https://github.com/espressif/arduino-esp32)
+* [Teensyduino 1.56](https://www.pjrc.com/teensy/td_download.html)
 
 This library is *not* compatible with:
 
@@ -1949,6 +1951,9 @@ and [Issue #66](https://github.com/bxparks/AUnit/issues/66)).
 
 It should work with [PlatformIO](https://platformio.org/) but I have
 not tested it extensively.
+
+The library works under Linux or MacOS (using both g++ and clang++ compilers)
+using the EpoxyDuino (https://github.com/bxparks/EpoxyDuino) emulation layer.
 
 <a name="OperatingSystem"></a>
 ### Operating System

--- a/docs/doxygen.cfg
+++ b/docs/doxygen.cfg
@@ -38,7 +38,7 @@ PROJECT_NAME           = "AUnit"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.6.0
+PROJECT_NUMBER         = 1.6.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=AUnit
-version=1.6.0
+version=1.6.1
 author=Brian T. Park <brian@xparks.net>
 maintainer=Brian T. Park <brian@xparks.net>
 sentence=A unit testing framework for Arduino platforms inspired by ArduinoUnit and Google Test.
-paragraph=The unit tests run in the embedded controller, not in a simulator or emulator. It is almost a drop-in replacement of ArduinoUnit with some advantages. AUnit supports timeouts and test fixtures. It somtimes consume 50% less flash memory on the AVR platform, and it has been tested to work on the AVR, ESP8266, ESP32, Teensy and STM32 platforms. Unit tests can often be executed on a Linux or MacOS desktop class machine using EpoxyDuino. Tests can be incorporated into a continuous integration system like Jenkins (using AUniter) or GitHub Actions (using EpoxyDuino).
+paragraph=The unit tests can run on the embedded controller. They can also run on Linux, MacOS, or FreeBSD environments using EpoxyDuino, which allows AUnit to be used in a Continuous Integration environment like GitHub Workflows. AUnit is almost a drop-in replacement of ArduinoUnit with some advantages. AUnit supports timeouts and test fixtures. It somtimes consume 50% less flash memory on the AVR platform, and it has been tested to work on the AVR, STM32, ESP8266, ESP32, Teensy platforms.
 category=Other
 url=https://github.com/bxparks/AUnit
 architectures=*

--- a/src/AUnit.h
+++ b/src/AUnit.h
@@ -45,14 +45,8 @@ SOFTWARE.
 #ifndef AUNIT_AUNIT_H
 #define AUNIT_AUNIT_H
 
-// Blacklist boards using new Arduino API due to incompatibilities. This
-// currently includes all megaAVR boards and SAMD21 boards using arduino::samd
-// >= 1.8.10. Boards using arduino:samd <= 1.8.9 or SparkFun:samd are fine.
-#if defined(ARDUINO_ARCH_MEGAAVR)
-#error MegaAVR not supported, https://github.com/bxparks/AUnit/issues/56
-#elif defined(ARDUINO_ARCH_SAMD) && defined(ARDUINO_API_VERSION)
-#error SAMD21 with arduino:samd >= 1.8.10 not supported, https://github.com/bxparks/AUnit/issues/66
-#elif defined(ARDUINO_API_VERSION)
+// Blacklist boards using new Arduino API due to incompatibilities.
+#if defined(ARDUINO_API_VERSION)
 #error Platforms using ArduinoCore-API not supported
 #endif
 
@@ -71,7 +65,7 @@ SOFTWARE.
 #include "aunit/TestMacros.h"
 
 // Version format: xxyyzz == "xx.yy.zz"
-#define AUNIT_VERSION 10600
-#define AUNIT_VERSION_STRING "1.6.0"
+#define AUNIT_VERSION 10601
+#define AUNIT_VERSION_STRING "1.6.1"
 
 #endif

--- a/src/AUnitVerbose.h
+++ b/src/AUnitVerbose.h
@@ -35,14 +35,8 @@ SOFTWARE.
 #ifndef AUNIT_AUNIT_VERBOSE_H
 #define AUNIT_AUNIT_VERBOSE_H
 
-// Blacklist boards using new Arduino API due to incompatibilities. This
-// currently includes all megaAVR boards and SAMD21 boards using arduino::samd
-// >= 1.8.10. Boards using arduino:samd <= 1.8.9 or SparkFun:samd are fine.
-#if defined(ARDUINO_ARCH_MEGAAVR)
-#error MegaAVR not supported https://github.com/bxparks/AUnit/issues/56
-#elif defined(ARDUINO_ARCH_SAMD) && defined(ARDUINO_API_VERSION)
-#error SAMD21 with arduino:samd >= 1.8.10 not supported, see https://github.com/bxparks/AUnit/issues/66
-#elif defined(ARDUINO_API_VERSION)
+// Blacklist boards using new Arduino API due to incompatibilities.
+#if defined(ARDUINO_API_VERSION)
 #error Platforms using ArduinoCore-API not supported
 #endif
 
@@ -61,7 +55,7 @@ SOFTWARE.
 #include "aunit/TestMacros.h"
 
 // Version format: xxyyzz == "xx.yy.zz"
-#define AUNIT_VERSION 10600
-#define AUNIT_VERSION_STRING "1.6.0"
+#define AUNIT_VERSION 10601
+#define AUNIT_VERSION_STRING "1.6.1"
 
 #endif

--- a/tests/AUnitTest/AUnitTest.ino
+++ b/tests/AUnitTest/AUnitTest.ino
@@ -422,6 +422,7 @@ test(voidPointer) {
 test(nullPointer) {
   const int aa[] = {1, 2};
   const long bb[] = {1, 2};
+  // const char cc[] = "ab";
   const int* dd = nullptr;
 
   assertFalse(compareEqual(aa, nullptr));


### PR DESCRIPTION
* 1.6.1 (2022-02-02)
    * Upgrade tool chain.
        * Arduino IDE from 1.8.13 to 1.8.19
        * Arduino CLI from 0.14.0 to 0.19.2
        * Arduino AVR Core from 1.8.3 to 1.8.4
        * STM32duino from 2.0.0 to 2.2.0
        * ESP8266 Core from 2.7.4 to 3.0.2
        * ESP32 Core from 1.0.6 to 2.0.2
        * Teensyduino from 1.54 to 1.56
    * Downgrade SAMD21 boards into new "Tier 3: May work but unsupported"
      category.
    * This is a maintenance release. No functional change.