### PR TITLE
TestRunner.{h,cpp}: use std::chrono for time ellapsed count

### DIFF
--- a/src/aunit/TestRunner.cpp
+++ b/src/aunit/TestRunner.cpp
@@ -161,9 +161,8 @@ void TestRunner::resolveRun() const {
   if (!isVerbosity(Verbosity::kTestRunSummary)) return;
   Print* printer = Printer::getPrinter();
 
-  unsigned long elapsedTime = mEndTime - mStartTime;
   printer->print(F("TestRunner duration: "));
-  printSeconds(printer, elapsedTime);
+  printSeconds(printer, ellapsedMs());
   printer->println(" seconds.");
 
   printer->print(F("TestRunner summary: "));


### PR DESCRIPTION
Hello Brian

As you already know, I'm working on a fork of EpoxyDuino that make it possible to add injection script and to simulate clock in order to make it easier to write unit tests.

But this leads to a bug when running tests with AUnit because AUnit uses millis().

IMHO AUnit should use the system clock and should not use millis().

Here is a patch that uses std::chrono that fixes this problem.

Best regards